### PR TITLE
feat(ui): support dark mode

### DIFF
--- a/card.js
+++ b/card.js
@@ -551,9 +551,9 @@ function createCardSEInput(parentSEInput, idCardCur, board) {
 	var rowStatus = $("<tr>").addClass("agile-card-background");
 	var rowPad = $("<tr>").addClass("agile-card-background").append($("<td style='font-size:50%;'>&nbsp;</td>").addClass("agile_tablecellItem"));
 
-	containerBar.append(row).append(rowStatus).append(rowPad);
+	containerBar.append($('<tbody class="agile-card-background">')).append(row).append(rowStatus).append(rowPad);
 
-	var comboUsers = setSmallFont($('<select id="plusCardCommentUsers"></select>').addClass("agile_general_box_input"));
+	var comboUsers = setSmallFont($('<select id="plusCardCommentUsers"></select>').addClass("agile_general_box_input agile_combo_input"));
 	comboUsers.attr("title", "Click to select the user for this new S/E row.");
 	fillComboUsers(true, comboUsers, "", idCardCur, board);
 	comboUsers.change(function () {
@@ -569,7 +569,7 @@ function createCardSEInput(parentSEInput, idCardCur, board) {
 	        rememberSEUser(val);
 	});
 
-	var comboDays = setSmallFont($('<select id="plusCardCommentDays"></select>').addClass("agile_days_box_input"));
+	var comboDays = setSmallFont($('<select id="plusCardCommentDays"></select>').addClass("agile_days_box_input agile_combo_input"));
 	comboDays.attr("title", "Click to pick how many days ago it happened.");
 
 	fillDaysList(comboDays, 0);
@@ -621,19 +621,19 @@ function createCardSEInput(parentSEInput, idCardCur, board) {
 	            });
 	        }
 	});
-	var spinS = setNormalFont($('<input id="plusCardCommentSpent" placeholder="S" maxlength="10"></input>').addClass("agile_spent_box_input agile_placeholder_small agile_focusColorBorder"));
+	var spinS = setNormalFont($('<input id="plusCardCommentSpent" placeholder="S" maxlength="10"></input>').addClass("agile_spent_box_input agile_placeholder_small agile_text_input"));
 	spinS.attr("title", "Click to type Spent.\nIf needed, Plus will increase E (right) when your total S goes over E.");
 	spinS[0].onkeypress = function (e) { validateSEKey(e); checkEnterKey(e); };
     //thanks for "input" http://stackoverflow.com/a/14029861/2213940
 	spinS.bind("input", function (e) { updateEOnSChange(); });
-	var spinE = setNormalFont($('<input id="plusCardCommentEstimate" placeholder="E" maxlength="10"></input>').addClass("agile_estimation_box_input agile_placeholder_small agile_focusColorBorder"));
+	var spinE = setNormalFont($('<input id="plusCardCommentEstimate" placeholder="E" maxlength="10"></input>').addClass("agile_estimation_box_input agile_placeholder_small agile_text_input"));
 	var spanSpinE = $('<span>');
 	spanSpinE.append(spinE);
 	spinE.attr("title", "Click to type Estimate.");
 	spinE[0].onkeypress = function (e) { validateSEKey(e); checkEnterKey(e); };
 	spinE.bind("input", function (e) { updateNoteR(); });
 	var slashSeparator = setSmallFont($("<span>").text("/"));
-	var comment = setNormalFont($('<input type="text" maxlength="250" name="Comment" placeholder="note"/>').attr("id", "plusCardCommentComment").addClass("agile_comment_box_input agile_placeholder_small"));
+	var comment = setNormalFont($('<input maxlength="250" name="Comment" placeholder="Comment"/>').attr("id", "plusCardCommentComment").addClass("agile_comment_box_input agile_placeholder_small agile_text_input"));
 
 	if (g_bNoEst) {
 	    slashSeparator.addClass("agile_hidden");
@@ -648,7 +648,7 @@ function createCardSEInput(parentSEInput, idCardCur, board) {
 	icon.addClass("agile-spent-icon-cardcommentSE");
 	spanIcon.append(icon);
 
-	var buttonEnter = setSmallFont($('<button id="plusCardCommentEnterButton"/>').addClass("agile_enter_box_input").text("Enter"));
+	var buttonEnter = setSmallFont($('<button id="plusCardCommentEnterButton"/>').addClass("agile_enter_box_input").addClass("agile_buton").text("Enter"));
 	buttonEnter.attr('title', 'Click to enter this S/E.');
 	row.append($('<td />').addClass("agile_tablecellItem").append(spanIcon));
 	var bAppendKW = false;
@@ -1097,7 +1097,7 @@ function fillCardSEStats(tableStats,callback) {
                     };
 
                     var rowHeader = addCardSERowData(headTable, dataRowHeader, true);
-                    var bodyTable = $("<tbody>");
+                    var bodyTable = $('<tbody class="agile-card-background">');
                     bModifiedHeaderE = false;
                     var sTotalCard = 0;
                     var eTotalCard = 0;
@@ -1208,24 +1208,26 @@ function showSETotalEdit(idCardCur, user) {
 <a class="agile_mtse_kwReportLink agile_linkSoftColor" href="" target="_blank">view keyword report</a> \
 <br>Date to modify: <select class="agile_mtse_day"></select>\
 <table class="agile_seTotalTable"> \
+<tbody class="agile-card-background"> \
 <tr> \
 <td align="left">S sum</td> \
 <td align="left">E sum</td> \
 <td align="left">R</td> \
 </tr> \
 <tr> \
-<td align="left"><input class="agile_modify_total_se_input agile_mtse_s" maxlength="10"></input></td> \
-<td align="left"><input class="agile_modify_total_se_input agile_mtse_e" maxlength="10"></input></td> \
-<td align="left"><input class="agile_modify_total_se_input agile_mtse_r" maxlength="10"></input></td> \
+<td align="left"><input class="agile_modify_total_se_input agile_mtse_s agile_text_input" maxlength="10"></input></td> \
+<td align="left"><input class="agile_modify_total_se_input agile_mtse_e agile_text_input" maxlength="10"></input></td> \
+<td align="left"><input class="agile_modify_total_se_input agile_mtse_r agile_text_input" maxlength="10"></input></td> \
 <td title="change your units from Plus Preferences" align="left"><span class="agile_mtse_units"></span></td> \
 </tr> \
+</tbody> \
 </table> \
-<input class="agile_se_note agile_placeholder_small" placeholder="type an optional note" maxlength="250"></input> \
-<button id="agile_modify_SETotal">Modify</button> \
-<button id="agile_cancel_SETotal">Cancel</button> \
+<input class="agile_se_note agile_placeholder_small agile_text_input" placeholder="type an optional note" maxlength="250"></input> \
+<button id="agile_modify_SETotal" class="agile_buton">Modify</button> \
+<button id="agile_cancel_SETotal" class="agile_buton">Cancel</button> \
 <br><br><p class="agile_mtseMessage agile_lightMessage"></p> \
 <br>\
-<span class="agile_lightMessage">Use "Modify" or use the "S/E bar" ?<br>Modify a 1ˢᵗ estimate ? See </span> <button class="agile_modify_help" style="display:inline-block;"  href="">help</button> \
+<span class="agile_lightMessage">Use "Modify" or use the "S/E bar" ?<br>Modify a 1ˢᵗ estimate ? See </span> <button class="agile_modify_help agile_buton" style="display:inline-block;"  href="">help</button> \
 </dialog>');
         getDialogParent().append(divDialog);
         divDialog = $(".agile_dialog_editSETotal");
@@ -1747,8 +1749,8 @@ function addCardCommentHelp() {
 				const div = $("<div class='no-print'></div>");
 				div.append(createRecurringCheck());
 				createHashtagsList(div);
+				div.append('<span style="margin-left:1px">&nbsp;&nbsp;</span>');
 				createSEMenu(div);
-
 				windowHeaderElement.append(div[0]);
 			}
 		}
@@ -2811,7 +2813,7 @@ function showSEHelpDialog(section) {
 <dialog class="agile_dialog_SEHelp agile_dialog_DefaultStyle"> \
 <img style="float:right;cursor:pointer;" id="agile_dialog_SEHelp_OK" src="' + chrome.extension.getURL("images/close.png") + '"></img>\
 <h2 id="agile_dialog_SEHelp_Top" style="outline: none;" align="center">Spent / Estimates help</h2>\
-<select tabindex="1" id="agile_sehelp_combotopic">\
+<select tabindex="1" id="agile_sehelp_combotopic" class="agile_combo_input">\
     <option value="welcome">Click here to pick a help topic</option>\
     <option value="addest">Add user estimate or global estimate</option>\
     <option value="addspent">Add user spent</option>\

--- a/cardetransfer.js
+++ b/cardetransfer.js
@@ -25,25 +25,28 @@ function showTransferEDialogWorker(userLast) {
 <select class="agile_transferE_keywords agile_combo_smaller" title="Pick the keyword for this modification."></select> \
 <a class="agile_transferE_kwReportLink agile_linkSoftColor" href="" target="_blank">view keyword report</a> \
 <table class="agile_seTotalTable"> \
+<tbody class="agile-card-background"> \
 <tr> \
 <td align="left" class="agile-etransfer-tcel-header">From</td> \
 <td align="left" class="agile-etransfer-tcel-header">To</td> \
 <td align="left" class="agile-etransfer-tcel-header" style="white-space: nowrap;">E ' + UNITS.getLongFormat(UNITS.current,g_bDisplayPointUnits) + '</td> \
 </tr> \
 <tr> \
-<td align="left"><select class="agile_transferE_user_from agile_combo_regular" title="Pick the \'from\' user."></select></td> \
-<td align="left"><select autofocus class="agile_transferE_user_to agile_combo_regular" title="Pick the \'to\' user."></select></td> \
-<td align="left"><input class="agile_transferE_e" maxlength="10"</input></td> \
+<td align="left"><select class="agile_transferE_user_from agile_combo_regular agile_combo_input agile_focusColorBorder" title="Pick the \'from\' user."></select></td> \
+<td align="left"><select autofocus class="agile_transferE_user_to agile_combo_regular agile_combo_input agile_focusColorBorder" title="Pick the \'to\' user."></select></td> \
+<td align="left"><input class="agile_transferE_e agile_text_input" maxlength="10"</input></td> \
 </tr> \
+</tbody> \
 </table> \
-<input class="agile_se_note agile_placeholder_small" placeholder="type an optional note"  maxlength="250"></input> \
+<input class="agile_se_note agile_placeholder_small agile_text_input" placeholder="type an optional note"  maxlength="250"></input> \
 <label class="agile_unselectable" style="vertical-align: middle;font-weight:normal;line-height:1em;"><input type="checkbox" class="agile_transfere_alsospend" style="vertical-align: middle;margin-bottom:4px;margin-top:4px;" /> Immediately spend the transferred ' + UNITS.getLongFormat(UNITS.current, g_bDisplayPointUnits) + '.</label>\
-<button id="agile_enter_transferE">Enter</button> \
-<button id="agile_cancel_transferE">Cancel</button> \
-<button id="agile_help_transferE" style="display:inline-block;float:right;">Help</button> \
+<button id="agile_enter_transferE" class="agile_buton">Enter</button> \
+<button id="agile_cancel_transferE" class="agile_buton">Cancel</button> \
+<button id="agile_help_transferE" class="agile_buton" style="display:inline-block;float:right;">Help</button> \
 <p class="agile_transferEMessage agile_lightMessage">&nbsp;</p> \
 <br> \
 <table style="agile-etransfer-stats">\
+<tbody class="agile-card-background"> \
 <tr class="agile-card-background-header">\
 <td style="width:50%;">User balances after Enter</td>\
 <td style="width:15%;">S <span style="font-size:0.85em">sum</span></td>\
@@ -61,6 +64,7 @@ function showTransferEDialogWorker(userLast) {
 <td class="agile-etransfer-cell agile-etransfer-tcel-to-s"></td>\
 <td class="agile-etransfer-cell agile-etransfer-tcel-to-e"></td>\
 <td class="agile-etransfer-cell agile-etransfer-tcel-to-r"></td>\
+</tbody>\
 </table>\
 </dialog>');
         getDialogParent().append(divDialog);

--- a/css/style.css
+++ b/css/style.css
@@ -6,23 +6,21 @@
     }
 }
 
-
-.select2-search { background-color: #EDEFF0 !important; }
-.select2-search input { background-color: #EDEFF0 !important; }
-.select2-results { background-color: #EDEFF0 !important; }
-.select2-selection { background-color: #EDEFF0 !important; }
+.select2-search input { background-color: var(--ds-background-neutral) !important; }
+.select2-selection { background-color: var(--ds-background-neutral) !important; }
 .select2-selection--single {
-    background-color: #EDEFF0 !important;
+    background-color: var(--ds-background-neutral) !important;
     border: none !important;
     font-size:12px !important;
-
 }
 
-.select2-selection__rendered {
-        color:#8C8C8C !important;
+.select2-container--default .select2-selection--single .select2-selection__placeholder {
+	color:var(--ds-text) !important;
 }
 
-.select2-container--default { background-color: #EDEFF0 !important; }
+.select2-dropdown {
+	background-color: var(--ds-surface-overlay) !important;
+}
 
 .bsmListCustomColumns {
   width: 14em;
@@ -139,6 +137,8 @@ list-style-type:disc !important;
   border: none;
   border-radius: 4px;
   box-shadow: 0 5px 9px rgba(0, 0, 0, 0.7);
+  background-color: var(--ds-surface-overlay);
+  color: var(--ds-text);
 }
 
 .agile_image_recurring_back {
@@ -149,7 +149,7 @@ list-style-type:disc !important;
 }
 
 .agile_remaining_background {
-    background: #DEEEDE !important;
+    background: var(--ds-background-success) !important;
 }
 
 #agile_dialog_FatalError {
@@ -236,11 +236,10 @@ list-style-type:disc !important;
 
 .agile_se_note {
     width:25em !important;
-    background:white !important;
 }
 
 .agile_lightMessage {
-        color:darkgray !important;
+        color:var(--ds-text-subtle) !important;
 }
 
 .agile_mtseMessage {
@@ -263,7 +262,6 @@ list-style-type:disc !important;
 	margin-bottom: 0px !important;
 	min-height: 10px !important;
 	padding: 1px !important;
-	background-color: white !important;
 	width: 4em;
 }
 
@@ -308,7 +306,7 @@ div.agile_box {
 }
 
 .agile_box_partialUpdate {
-    color: #D9D9D9 !important;
+    color: var(--dynamic-text);
 }
 
 .agile_plus_filter_old {
@@ -372,8 +370,8 @@ div.agile_total_box {
 	margin-right: 5px;
     cursor:default;
     border-radius:4px;
-    border: solid 1px rgba(255, 255, 155, .2);
-    color: #f6f6f6;
+    border: solid 1px var(--ds-border-inverse);
+    color: var(--dynamic-text);
     background-color: transparent;
     min-width:1em !important;
     font-weight:normal !important;
@@ -416,7 +414,7 @@ label.agile_ignore_filters_option input {
 .agile_badge {
 	padding-left: 4px !important;
     border-radius:3px;
-    color: #8c8c8c !important;
+    color: var(--ds-text-subtle) !important;
     min-width:.9em !important;
     text-align:center !important;
     cursor:default !important;
@@ -437,8 +435,8 @@ div.agile_badge_cardfront {
     text-align:center !important;
     font-size:12px !important;
     display: inline-block;
-    color: #8c8c8c !important;
-    border-color: #B7B7B7 !important;
+    color: var(--ds-text-subtle) !important;
+    border-color: var(--ds-text-subtle) !important;
 }
 
 .agile_badge_cardfrontFirst {
@@ -463,7 +461,7 @@ div.agile_badge_cardfront {
 
 .agile_badge_estimate {
 	border: 1px solid #E2E2E2;
-    color: #8c8c8c !important;
+    color: var(--ds-text-subtle) !important;
 }
 
 .agile_badge_estimate:hover {
@@ -473,7 +471,7 @@ div.agile_badge_cardfront {
 
 .agile_badge_spent {
 	border: 1px solid #E2E2E2;
-    color: #8c8c8c !important;
+    color: #var(--ds-text-subtle) !important;
     margin-right: 3px !important;
 }
 
@@ -484,7 +482,7 @@ div.agile_badge_cardfront {
 
 .agile_badge_remaining {
 	border: 1px solid #E2E2E2;
-    color: #8c8c8c !important;
+    color: #var(--ds-text-subtle) !important;
 }
 
 .agile_badge_remaining:hover {
@@ -508,7 +506,7 @@ div.agile_badge_cardfront {
 
 .agile_badge_hashtag_primary {
 	line-height: 17px;
-	color: #8c8c8c;
+	color: var(--ds-text-subtle);
 	padding: 1px 5px 0px 5px !important;
     margin: -2px 6px 8px 0px !important;
 	border-radius: 7px !important;
@@ -517,7 +515,7 @@ div.agile_badge_cardfront {
 
 .agile_badge_hashtag_secondary {
 	line-height: 17px;
-	color: #8c8c8c;
+	color: var(--ds-text-subtle);
 	padding: 1px 5px 0px 5px !important;
     margin: -2px 6px 8px 0px !important;
 	border-radius: 7px !important;
@@ -560,10 +558,10 @@ div#qunit-container {
  */
 div#agile_help_container {
 	outline: #999999 1px solid;
-	background: #FAFAFA;
+	background: var(--ds-surface);
 	border-top-right-radius: 5px;
 	border-bottom-right-radius: 5px;
-	color: #4D4D4D;
+	color: var(--ds-text);
 	left: 0;
 	padding: 12px;
 	padding-bottom: 10px;
@@ -804,8 +802,7 @@ div#agile_help_container h3 {
 
 
 .agile_spent_item_title_zoomable:hover {
-    color:#23719F !important;
-    
+    color: var(--ds-text-brand) !important;
 }
 
 .agile_spent_item_title {
@@ -834,7 +831,7 @@ div#agile_help_container h3 {
 }
 
 .agile-card-background {
-	background-color: #F0F0F0 !important;
+	background-color:rgba(0, 0, 0, 0);
 }
 
 td.agile_cell_drilldown {
@@ -982,7 +979,7 @@ th.agile_drill_th_extend {
 }
 
 .agile-card-background-header {
-	background-color: #D0D0D0 !important;
+	background-color: var(--ds-background-neutral) !important;
     white-space: nowrap !important;
 }
 
@@ -991,7 +988,7 @@ th.agile_drill_th_extend {
 }
 
 .agile_se_checks {
-    color: #8c8c8c !important;
+    color: var(--ds-text-subtle) !important;
 }
 
 .agile-se-bar-table {
@@ -1009,7 +1006,7 @@ table#idTableSpentItemsHome td {
 	}
 
 .newTrelloHomeBackground {
-    background-color: #f8f9f9 !important;
+    background-color: var(--ds-surface) !important;
 }
 
 .seContainerNewTrello {
@@ -1157,7 +1154,6 @@ table#tableMarkers td {
     -webkit-user-select: none;  
     user-select: none;
 }
-}
 
 .agile-spent-icon-header_cardwindow {
     float:right;
@@ -1178,14 +1174,13 @@ table#tableMarkers td {
 	text-decoration: none !important;
 	padding: 2px !important;
 	border-radius: 3px !important;
-	color: #f3f3f3 !important;
+	color: var(--dynamic-text) !important;
 	vertical-align: top !important;
 	font-size: 9px !important;
 }
 
 .agile_plus_header_link:hover {
-	background-color: #E0E0E0 !important;
-	color: #444 !important;
+	background-color: var(--dynamic-button-hovered);
 }
 
 .agile_tour_link_mini {
@@ -1393,6 +1388,20 @@ table#tableMarkers td {
 	vertical-align: middle;
 }
 
+.agile_combo_input:hover {
+    background-color: var(--ds-background-input-hovered) !important;
+}
+
+.agile_combo_input:focus {
+	outline: none;
+    box-shadow: 0 0 0 2px inset var(--ds-border-brand) !important;
+    border-color: #00000000;
+}
+
+.agile_combo_input {
+    border-radius: 3px !important;
+    background-color: var(--ds-background-input);
+}
 
 .agile_combo_regular {
     width:auto !important;
@@ -1418,12 +1427,12 @@ table#tableMarkers td {
 	margin-top: 0px !important;
 	margin-bottom: 0px !important;
 	min-height: 14px !important;
-	background-color: white !important;
+	background-color: var(--ds-background-input) !important;
 	height: 22px;
     width: 100% !important;
 	display: inline !important;
 	-webkit-appearance: none !important;
-	border-color: #BFBFBF !important;
+	border-color: var(--ds-border) !important;
 	border-radius: 3px !important;
 }
 
@@ -1433,12 +1442,12 @@ table#tableMarkers td {
 	margin-top: 0px !important;
 	margin-bottom: 0px !important;
 	min-height: 14px !important;
-	background-color: white !important;
+	background-color: var(--ds-background-input) !important;
 	width: 35px;
 	height: 22px;
 	display: inline !important;
 	-webkit-appearance: none !important;
-	border-color: #BFBFBF !important;
+	border-color: var(--ds-border) !important;
 	border-radius: 3px !important;
 }
 
@@ -1446,9 +1455,10 @@ table#tableMarkers td {
 	background-color: #5188A8 !important;
 }
 
-.agile_weeks_combo_element {
-    color:black !important;
+.agile_title_combo_element {
+    color: var(--ds-text) !important;
     direction: ltr !important;
+    background-color: var(--ds-surface-overlay) !important;
 }
 
 .agile_users_combo_element_disabled {
@@ -1468,7 +1478,7 @@ table#tableMarkers td {
 }
 
 .agile_SER_normal * {
-    color: #8c8c8c !important;
+    color: var(--ds-text-subtle) !important;
 }
 
 .agile_users_combo {
@@ -1529,11 +1539,15 @@ table#tableMarkers td {
         font-weight:bold !important;
 }
 
-.agile_weeks_combo {
+.agile-title-box {
+
+}
+
+.agile_title_combo {
     direction: rtl !important;
 	text-decoration: none !important;
 	padding: 0px !important;
-	color: #f3f3f3 !important;
+	color: var(--dynamic-text) !important;
 	vertical-align: top !important;
 	font-size: 12px !important;
 	margin-bottom: 0px !important;
@@ -1545,21 +1559,25 @@ table#tableMarkers td {
 	height: 20px;
 	display: inline;
 	-webkit-appearance: none;
-    border-width: 1px !important;
     border-radius: 3px !important;
-    border-color: rgba(255,255,255,0) !important;
+    border: solid 1px var(--ds-border-inverse);
 }
 
-.agile_weeks_combo:hover {
-		border-color: #F0F0F0 !important;
+.agile_title_combo_input:hover {
+    background-color: var(--dynamic-button-hovered) !important;
 }
+
+.agile_title_combo_input {
+    background-color: var(--dynamic-button) !important;
+}
+
 .agile_tour_link {
     margin-right:3px;
     cursor: pointer;
 }
 
 .agile_placeholder_small::-webkit-input-placeholder {
-    color:    #C7C7C7 !important;
+    color:    var(--ds-text-subtlest) !important;
     font-size: 0.8em !important;
 }
 
@@ -1584,14 +1602,13 @@ table#tableMarkers td {
 	margin-bottom: 0px !important;
 	min-height: 10px !important;
 	padding: 1px !important;
+	background-color: var(--ds-background-input) !important;
+	box-shadow: 0 0 0 1px inset var(--ds-border-input);
+	border: none;
+	box-sizing: border-box;
+	border-radius: 3px;
 	width: 40px;
 	display: inline !important;
-    background-color: white !important;
-}
-
-.agile_focusColorBorder:focus {
-    box-shadow: 0 0 2px #298FCA !important;
-    border-color: #298FCA !important;
 }
 
 .agile_estimation_box_input {
@@ -1600,11 +1617,14 @@ table#tableMarkers td {
 	margin-bottom: 0px !important;
 	min-height: 10px !important;
 	padding: 1px !important;
-	background-color: white !important;
+	background-color: var(--ds-background-input) !important;
+	box-shadow: 0 0 0 1px inset var(--ds-border-input);
+	border: none;
+	box-sizing: border-box;
+	border-radius: 3px;
 	width: 40px;
 	display: inline !important;
 }
-
 
 .agile_comment_box_input {
 	display: inline !important;
@@ -1614,7 +1634,10 @@ table#tableMarkers td {
 	margin-bottom: 0px !important;
 	min-height: 10px !important;
 	width: 100% !important;
-	background-color: white !important;
+	background-color: var(--ds-background-input) !important;
+	box-shadow: 0 0 0 1px inset var(--ds-border-input);
+	border-radius: 3px;
+	border: none;
 }
 
 .agile_enter_box_input {
@@ -1627,7 +1650,6 @@ table#tableMarkers td {
 	min-height: 10px !important;
 	background-image: none !important;
 	background: none !important;
-	background-color: #D0D0D0 !important;
 	border: 1px !important;
     width: 3.3em !important;
 }
@@ -1707,7 +1729,6 @@ table#tableMarkers td {
     margin-bottom:0px;
     margin-top:10px;
     line-height: 17px !important;
-    border-color: 
 }
 
 .agile_tabselector_list table tr {
@@ -1716,25 +1737,21 @@ table#tableMarkers td {
 
 .agile-card-seByUserModify {
     border: none !important;
-    background-color:#EDEFF0 !important;
 }
 
 .agile_linkSoftColor {
-    color:#8C8C8C !important;
+    color:var(--ds-text-subtle) !important;
     font-size:12px !important;
     cursor: pointer;
     margin-right:1em;
     -webkit-touch-callout: none;
     -webkit-user-select: none;  
     user-select: none;
-}
-
-.agile_linkSoftColor:hover {
-    color:#444 !important;
+	text-decoration: underline;
 }
 
 .agile_urlUser {
-	color: #f3f3f3 !important;
+    color: var(--dynamic-text) !important;
     padding: 0px !important;
     margin: 0px !important;
 }
@@ -1765,8 +1782,7 @@ table#tableMarkers td {
 }
 
 .agile_urlUserTable:hover {
-	background-color: #E0E0E0 !important;
-	color: #444 !important;
+	background-color: var(--dynamic-button-hovered) !important;
 }
 
 .agile_urlUserTable tbody {
@@ -2079,7 +2095,6 @@ float:left;
 .agile_card_combo {
     width:auto;
     border:none;
-    background-color:#EDEFF0;
     margin-right:1.5em !important;
 }
 
@@ -2187,4 +2202,26 @@ float:left;
     height: 20px;
     float: left;
     margin: 0 0 0 0;
+}
+
+.agile_buton {
+	background-color: var(--ds-background-neutral) !important;
+}
+
+.agile_buton:hover {
+	background-color: var(--ds-background-neutral-hovered) !important;
+}
+
+.agile_text_input:focus {
+    box-shadow: 0 0 0 2px inset var(--ds-border-brand) !important;
+    border: none !important;
+}
+
+.agile_text_input:hover {
+    background-color: var(--ds-background-input-hovered) !important;
+}
+
+.agile_text_input {
+	background-color: var(--ds-background-input) !important;
+	box-shadow: 0 0 0 1px inset var(--ds-border-input);
 }

--- a/help.js
+++ b/help.js
@@ -392,7 +392,7 @@ var Help = {
 <a class="agile_link_noUnderlineNever" href="https://www.linkedin.com/in/zigmandel" rel="publisher" target="_blank"> \
 <img src="https://www.linkedin.com/favicon.ico" title="Connect at LinkedIn" style="margin-bottom:-3px;margin-right:1px;border:0;width:16px;height:16px;"/></A></span>');
 	    }
-	    helpWin.para("version " + g_manifestVersion + "&nbsp;&nbsp<button style='float:right'>Close</button>").children("button").click(onClosePane);
+	    helpWin.para("version " + g_manifestVersion + "&nbsp;&nbsp<button style='float:right' class='agile_buton'>Close</button>").children("button").click(onClosePane);
 	    helpWin.para('Fixed by <a href="https://github.com/men232" target="_blank">Andrew L.</a>');
 
 	    helpWin.para("&nbsp;");
@@ -402,7 +402,7 @@ var Help = {
 	    }
 
 	    helpWin.para('<b><h3>Language</h3></b>');
-	    var pComboLang = helpWin.para('<select style="width:auto"></select>');
+	    var pComboLang = helpWin.para('<select style="width:auto" class="agile_combo_input"></select>');
 	    var comboLang = pComboLang.children('select');
 	    comboLang.append($(new Option("English", "en")));
 	    comboLang.append($(new Option("Chinese - 中文", "zh-CN")));
@@ -468,7 +468,7 @@ Plus is compatible with <A target="_blank" href="https://chrome.google.com/webst
 	    }
 	    
 	    if (getIdBoardFromUrl(document.URL) != "0jHOl1As") {
-	        helpWin.para("<div style='display:inline-block;border: 1px solid;border-radius:3px;border-color:RGB(77,77,77);padding:1em;background-color: #E4F0F6;'>Visit the <span style='font-weight:bold;font-size:110%;'><A target='_blank' href=''>Plus Help board</A></span> for the best place to learn about Plus.</div>").find("A").click(function (e) {
+	        helpWin.para("<div style='display:inline-block;border: 1px solid;border-radius:3px;border-color:var(--ds-border);padding:1em;background-color: var(--ds-background-inverse-subtle);'>Visit the <span style='font-weight:bold;font-size:110%;'><A target='_blank' href=''>Plus Help board</A></span> for the best place to learn about Plus.</div>").find("A").click(function (e) {
 	            window.open("https://trello.com/b/0jHOl1As/plus-for-trello-help", "_blank");
 	            e.preventDefault();
 	        });
@@ -608,7 +608,7 @@ Enable "➤ sync" below to see Reports, full Chrome Plus menu, team S/E and use 
 
 	    function addProSection() {
 	        helpWin.para('<h2 id="agile_pro_section">Plus Pro version</h2>');
-	        var paraPro = helpWin.para('<input style="vertical-align:middle;margin-bottom:0px;" type="checkbox" class="agile_checkHelp" value="checkedProVersion" id="agile_plus_checkPro" /><label style="display:inline-block;color:black !important;" for="agile_plus_checkPro">Enable "Pro" features</label>');
+	        var paraPro = helpWin.para('<input style="vertical-align:middle;margin-bottom:0px;" type="checkbox" class="agile_checkHelp" value="checkedProVersion" id="agile_plus_checkPro" /><label style="display:inline-block;color:var(--ds-text-brand) !important;" for="agile_plus_checkPro">Enable "Pro" features</label>');
 	        var checkEnablePro = paraPro.children('input:checkbox:first');
 	        var textEnablePro = '<div id="sectionWhyPro">If you love Plus, enable Pro!';
 
@@ -913,7 +913,7 @@ Enable "➤ sync" below to see Reports, full Chrome Plus menu, team S/E and use 
 	        window.open("https://trello.com/b/0jHOl1As/plus-for-trello-help", "_blank");
 	        e.preventDefault();
 	    });
-	    comboSync = helpWin.para('<select id="agile_idComboSync" style="width:auto;height:2em;">').children('select');
+	    comboSync = helpWin.para('<select id="agile_idComboSync" style="width:auto;height:2em;" class="agile_combo_input">').children('select');
 	    comboSync.append($(new Option("Sync off", SYNCMETHOD.disabled)).addClass("agile_box_input_hilite_red"));
 	    comboSync.append($(new Option("Recommended - Store inside Trello (S/E in Trello card comments)", SYNCMETHOD.trelloComments)).addClass("agile_normalBackground"));
 	    comboSync.append($(new Option("Stealth - Store outside Trello (S/E in Google spreadsheet)", SYNCMETHOD.googleSheetStealth)).addClass("agile_normalBackground"));
@@ -1300,7 +1300,7 @@ Enable "➤ sync" below to see Reports, full Chrome Plus menu, team S/E and use 
 	    helpWin.para('&nbsp');
 	    if (true) { //units
 	        var pComboUnits = helpWin.rawSE('<p><span>&bull; Work units: </span></p>');
-	        var comboUnits = $('<select style="width:auto">');
+	        var comboUnits = $('<select style="width:auto" class="agile_combo_input">');
 	        pComboUnits.append(comboUnits).append($('<span> Card timers measure time in your units. When changing units, S/E already entered is assumed in the new units so set your units here before entering any S/E.</span>'));
 	        comboUnits.append($(new Option(UNITS.getLongFormat(UNITS.minutes), UNITS.minutes)));
 	        comboUnits.append($(new Option(UNITS.getLongFormat(UNITS.hours), UNITS.hours)));
@@ -1391,7 +1391,7 @@ Enable "➤ sync" below to see Reports, full Chrome Plus menu, team S/E and use 
         //Week starts on
 	    if (true) {
 	        var pComboDow = helpWin.raw('<p><span>Week starts on </span></p>').addClass('agile_help_indent1');
-	        comboDowStart = $('<select style="width:auto">');
+	        comboDowStart = $('<select style="width:auto" class="agile_combo_input">');
 	        comboDowStart.appendTo(pComboDow);
 	        //comboDowStart.append($(new Option("saturday", "6"))); //dom: saturday not ready. many edge cases not handled.
 	        comboDowStart.append($(new Option("sunday", "0")));
@@ -1443,7 +1443,7 @@ Enable "➤ sync" below to see Reports, full Chrome Plus menu, team S/E and use 
 	    //enable support for custom weeks
 	    if (true) {
 	        var pComboWeekDelta = helpWin.raw('<p><span>Use any start day by shifting the week -back or +forward: </span></p>').addClass('agile_help_indent1');
-	        comboWeekDeltaStart = $('<select style="width:auto">');
+	        comboWeekDeltaStart = $('<select style="width:auto" class="agile_combo_input">');
 	        comboWeekDeltaStart.appendTo(pComboWeekDelta);
 	        pComboWeekDelta.append("<span> </span>");
 	        pComboWeekDelta.append($('<a href="">Tell me more</a>')).children('a').click(function (ev) {
@@ -1734,7 +1734,7 @@ Do not warn when starting a timer when another timer is active.</input>').childr
 	    }
 
 	    if (true) { //always show Spent in the Chrome icon, even when a timer is active.
-	        var comboSpentOnAppIcon = helpWin.paraSE('Show your weekly spent on the Chrome Plus icon? <select style="width:auto"></select>').children('select:first');
+	        var comboSpentOnAppIcon = helpWin.paraSE('Show your weekly spent on the Chrome Plus icon? <select style="width:auto" class="agile_combo_input"></select>').children('select:first');
 	        comboSpentOnAppIcon.append($(new Option("Yes except when there is an active timer", OPT_SHOWSPENTINICON_NORMAL)));
 	        comboSpentOnAppIcon.append($(new Option("Yes always (even with an active timer)", OPT_SHOWSPENTINICON_ALWAYS)));
 	        comboSpentOnAppIcon.append($(new Option("No, never show it.", OPT_SHOWSPENTINICON_NEVER)));
@@ -1774,7 +1774,7 @@ Do not show daily spent total popup notifications every time you enter spent.</i
 
         //Options to show mini-me card popups
 	    if (true) { 
-	        var comboCardPopupStyle = helpWin.para('Use <A href="https://trello.com/c/ZduasRWD/138-mini-me-card-popups" target="_blank">mini-me card popups</A> in reports and Chrome menu? <select style="width:auto"></select>').children('select:first');
+	        var comboCardPopupStyle = helpWin.para('Use <A href="https://trello.com/c/ZduasRWD/138-mini-me-card-popups" target="_blank">mini-me card popups</A> in reports and Chrome menu? <select style="width:auto" class="agile_combo_input"></select>').children('select:first');
 	        comboCardPopupStyle.append($(new Option("Yes, as small card popups (limited funcionality)", CARDPOPUPTYPE.POPUP_NOACTIONS)));
 	        comboCardPopupStyle.append($(new Option("Yes, as medium card popups (more functionality)", CARDPOPUPTYPE.POPUP_SOMEACTIONS)));
 	        comboCardPopupStyle.append($(new Option("No, open Trello cards in a Chrome tab", CARDPOPUPTYPE.NO_POPUP)));

--- a/plus.js
+++ b/plus.js
@@ -1305,7 +1305,7 @@ function fillRecentWeeksList(combo) {
         var textPretty = text;
         if (year==yearCur)
             textPretty = "W" + parts[1];
-        combo.append($(new Option(textPretty, text)).addClass('agile_weeks_combo_element').attr("title", title));
+        combo.append($(new Option(textPretty, text)).addClass('agile_title_combo_element').attr("title", title));
         daysDelta = 13; //7+6
     }
 
@@ -1324,7 +1324,7 @@ function adjustSelectWidthToContent(combo) {
 }
 
 function getRecentWeeksList() {
-    var combo = $('<select id="spentRecentWeeks" />').addClass("agile_weeks_combo agile_boldfont");
+    var combo = $('<select id="spentRecentWeeks" />').addClass("agile_title_combo agile_combo_input agile_boldfont agile_title_combo_input");
 	combo.css('cursor', 'pointer');
 	combo.attr("title", "click to change the week being viewed.");
 	if (g_bNoSE)
@@ -1360,7 +1360,7 @@ function getKeywordsViewList() {
         combo = g_bheader.comboSEView;
 
     if (combo.length == 0) {
-        combo = $('<select id="agile_globalkeywordlist"/>').addClass("agile_weeks_combo"); //review: rename agile_weeks_combo to generic
+        combo = $('<select id="agile_globalkeywordlist"/>').addClass("agile_title_combo agile_combo_input agile_title_combo_input");
         combo.css('cursor', 'pointer');
         combo.attr("title", "Plus - Click to change the S/E view");
     }
@@ -1386,7 +1386,7 @@ function getKeywordsViewList() {
         if (bMultipleKeywords)
             rgItems.push({ str: "↗ Report by keyword", val: VAL_COMBOVIEWKW_REPORTKW });
         rgItems.push({ str:  "↗ Dimensions help", val: VAL_COMBOVIEWKW_HELP });
-        fillComboKeywords(combo, rgItems, g_dimension, "agile_weeks_combo_element", '\u00A0\u00A0\u00A0', true);
+        fillComboKeywords(combo, rgItems, g_dimension, "agile_title_combo_element", '\u00A0\u00A0\u00A0', true);
         if (combo.val() != g_dimension) { //keyword no longer in use, default to all
             combo.val(VAL_COMBOVIEWKW_ALL);
             doComboChange();
@@ -1793,9 +1793,9 @@ function insertFrontpageChartsWorker(mainDiv, dataWeek, user) {
 		row2.append(cellD);
 		waiter.SetWaiting(true);
 		var divItemDashboardRecent = addModuleSection(true, false, cellA, "", idRecentModule, true, "left", false);
-		divItemDashboardRecent.addClass("agile_spent_item_title  agile_spent_item_combo").attr("title", "Your recent S/E.\n\nTip: control+click items to open in a new tab");
+		divItemDashboardRecent.addClass("agile_spent_item_title  agile_spent_item_combo agile_combo_input").attr("title", "Your recent S/E.\n\nTip: control+click items to open in a new tab");
 		var divItemDashboardUnspent = addModuleSection(true, false, cellA, "", idPendingModule, true, "left", false);
-		divItemDashboardUnspent.addClass("agile_spent_item_combo").attr("title", "Your remaining S/E.\n\nTip: control+click items to open in a new tab");
+		divItemDashboardUnspent.addClass("agile_spent_item_combo agile_combo_input").attr("title", "Your remaining S/E.\n\nTip: control+click items to open in a new tab");
 		if (bNewTrelloHome) {
 		    divItemDashboardRecent.addClass("newTrelloHomeBackground");
 		    divItemDashboardUnspent.addClass("newTrelloHomeBackground");


### PR DESCRIPTION
This patch use trello css variable to make plus-for-trello support dark mode.  It also make the color theme of plus-for-trello to closer with the trello color used.
I try to adjust all the color of components I have found, but maybe some are omitted. 
Please try it and don't hesitate to share your opinion. 
